### PR TITLE
Add basic export buttons to BREAD browse pages

### DIFF
--- a/app/Actions/CsvExportAll.php
+++ b/app/Actions/CsvExportAll.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Actions;
+
+use TCG\Voyager\Actions\AbstractAction;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Schema;
+
+class CsvExportAll extends AbstractAction
+{
+    public function getTitle()
+    {
+        return 'Export All';
+    }
+
+    public function getIcon()
+    {
+        return 'voyager-cloud-download';
+    }
+
+    public function getPolicy()
+    {
+        return 'read';
+    }
+
+    public function getAttributes()
+    {
+        return [
+            'class' => 'btn btn-sm btn-primary btn-add-new',
+        ];
+    }
+
+    public function getDefaultRoute()
+    {
+        return route('voyager.upload');
+    }
+
+    public function massAction($ids, $comingFrom)
+    {
+        $model = $this->dataType->model_name;
+        $columns = Schema::getColumnListing($this->dataType->name);
+        $rows = $model::all();
+        $filename = "{$this->dataType->slug}.csv";
+
+        $handle = fopen($filename, 'w+');
+        fputcsv($handle, $columns);
+
+        foreach($rows as $row) {
+            fputcsv($handle, $row->toArray());
+        }
+
+        fclose($handle);
+
+        $headers = array(
+            'Content-Type' => 'text/csv',
+        );
+
+        return Response::download($filename, $filename, $headers);
+    }
+}

--- a/app/Actions/CsvExportSelected.php
+++ b/app/Actions/CsvExportSelected.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Actions;
+
+use TCG\Voyager\Actions\AbstractAction;
+use Illuminate\Support\Facades\Response;
+use Illuminate\Support\Facades\Schema;
+
+class CsvExportSelected extends AbstractAction
+{
+    public function getTitle()
+    {
+        return 'Export Selected';
+    }
+
+    public function getIcon()
+    {
+        return 'voyager-cloud-download';
+    }
+
+    public function getPolicy()
+    {
+        return 'read';
+    }
+
+    public function getAttributes()
+    {
+        return [
+            'class' => 'btn btn-sm btn-primary btn-add-new',
+        ];
+    }
+
+    public function getDefaultRoute()
+    {
+        return route('voyager.upload');
+    }
+
+    public function massAction($ids, $comingFrom)
+    {
+        $model = $this->dataType->model_name;
+        $columns = Schema::getColumnListing($this->dataType->name);
+        $rows = $model::findMany($ids);
+        $filename = "{$this->dataType->slug}.csv";
+
+        $handle = fopen($filename, 'w+');
+        fputcsv($handle, $columns);
+
+        foreach($rows as $row) {
+            fputcsv($handle, $row->toArray());
+        }
+
+        fclose($handle);
+
+        $headers = array(
+            'Content-Type' => 'text/csv',
+        );
+
+        return Response::download($filename, $filename, $headers);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Events\Dispatcher;
+use TCG\Voyager\Facades\Voyager;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -23,6 +25,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Voyager::addAction(\App\Actions\CsvExportAll::class);
+        Voyager::addAction(\App\Actions\CsvExportSelected::class);
     }
 }


### PR DESCRIPTION
Adds 2 custom actions to export all records to CSV or to export only selected records to CSV.  Follows patter suggested in Voyager documentation for custom actions: https://voyager-docs.devdojo.com/customization/action-buttons